### PR TITLE
Use init_style as provider

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,9 +6,10 @@
 class consul_template::service {
 
   service { 'consul-template':
-    ensure => $consul_template::service_ensure,
-    enable => $consul_template::service_enable,
-    name   => 'consul-template',
+    ensure   => $consul_template::service_ensure,
+    enable   => $consul_template::service_enable,
+    provider => $consul_template::init_style,
+    name     => 'consul-template',
   }
 
 


### PR DESCRIPTION
This always defaults to `upstart` even in Jessie, so I have explicitly set this to look back at the main module's parameter, which we set via hiera.

/cc https://github.com/github/puppet/pull/12122

/cc @ross 
