### PR TITLE
Support namespaced consul custom function

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,7 +7,7 @@ class consul_template::config (
   $purge       = true,
 ) {
   # Using our parent module's pretty_config & pretty_config_indent just because
-  $content_full = consul_sorted_json($config_hash, $consul::pretty_config, $consul::pretty_config_indent)
+  $content_full = consul::sorted_json($config_hash, $consul::pretty_config, $consul::pretty_config_indent)
   # remove the closing } and it's surrounding newlines
   $content = regsubst($content_full, "\n}\n$", '')
 

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -44,7 +44,7 @@ define consul_template::watch (
   }
 
   $config_hash_all = deep_merge($config_hash_real, $config_source)
-  $content_full = consul_sorted_json($config_hash_all, $consul::pretty_config, $consul::pretty_config_indent)
+  $content_full = consul::sorted_json($config_hash_all, $consul::pretty_config, $consul::pretty_config_indent)
   $content = regsubst(regsubst($content_full, "}\n$", '}'), "\n", "\n    ", 'G')
   @concat::fragment { $frag_name:
     target  => 'consul-template/config.json',


### PR DESCRIPTION
We've adjusted our consul puppet module to conform with the puppet v4
api custom functions spec, with the side-effect that these functions are
now namespaced under the consul module.

Update the function references here to call the namespaced version of
those functions.