### PR TITLE
Define dependency on github/consul

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "gdhbashton-consul_template",
+  "name": "github-consul_template",
   "version": "0.2.8",
   "author": "gdhbashton",
   "summary": "Install and manage Consul Template and its jobs",
@@ -28,6 +28,7 @@
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=1.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">= 1.1.0" },
-    { "name": "nanliu/staging", "version_requirement": ">= 0.4.0" }
+    { "name": "nanliu/staging", "version_requirement": ">= 0.4.0" },
+    { "name": "github/consul", "version_requirement": ">= 1.0.0" }
   ]
 }


### PR DESCRIPTION
Welcome. This is a weird one. On the face of it we're simply adding a
relationship between this module (our own fork of the consul_template
module) and a module called `github/consul`, by making this module
require v1+ of the consul module.

Two things are unusual about this. Firstly, the source of the
`github/consul` module is actually within the puppet repo - originally
at `modules/consul` but now moved to `module_src/consul`. This module is
referenced in the puppet repo's Puppetfile only with its local path, so
that the librarian install step is able to "install" the consul module
and  satisfy dependencies of anything that depends on it. All that is to
say that if you try to use this consul_template module anywhere but the
github/puppet repo, librarian isn't going to be able to satisfy the
github/consul dependency. That's not wonderful, but it's a manageable
risk given how we've forked _both_ github/consul and this
consul_template module inhouse, and we currently have only one puppet
repository.

The appropriate question to ask is _why the heck are we doing this_: Our
fork of the consul module had puppet v3 functions defined, one of which
caused errors when we tried to serve the module through a v7
puppetserver. To fix this we updated the v3 functions to be puppet v4
compatible, but in doing so hit a puppet feature where you're unable to
call v4 functions in module B from module A unless module A defines a
dependency on module B in its metadata.json. Hence, this.

This limitation was removed in puppet 5.5+ but at the moment we're
having to support puppet-agent versions 4, 5 and 7 across the fleet
while we slowly migrate everything to puppet 7. I'm hopeful that if we
successfully roll puppet 7 out we can revisit this change and our module
structure in general, and remove these unnecessary hacks.
